### PR TITLE
[close #20] Require StringIO

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Master (unreleased)
+
+- Fix error by requiring `stringio` (https://github.com/red-data-tools/unicode_plot.rb/pull/22)
+
 # 0.0.3
 
 - Add histogram support

--- a/lib/unicode_plot.rb
+++ b/lib/unicode_plot.rb
@@ -1,3 +1,5 @@
+require 'stringio'
+
 require 'unicode_plot/version'
 
 require 'unicode_plot/utils'


### PR DESCRIPTION
When the `stringio` library is not required then using the examples gives us this error:

```
NameError (uninitialized constant UnicodePlot::StyledPrinter::StringIO)
```

By adding this require to the top level library file we guarantee it is always loaded.