### PR TITLE
UnicodePlot.histogram([1, 2]) shouldn't raise error

### DIFF
--- a/test/test-histogram.rb
+++ b/test/test-histogram.rb
@@ -108,5 +108,11 @@ class HistogramTest < Test::Unit::TestCase
       assert_equal(fixture_path("histogram/parameters2.txt").read,
                    output)
     end
+
+    test("issue #24") do
+      assert_nothing_raised do
+        UnicodePlot.histogram([1, 2])
+      end
+    end
   end
 end

--- a/unicode_plot.gemspec
+++ b/unicode_plot.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "enumerable-statistics", ">= 2.0.0.pre"
+  spec.add_runtime_dependency "enumerable-statistics", ">= 2.0.1"
 
   spec.add_development_dependency "bundler", ">= 1.17"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This will fix #24