### PR TITLE
Fix animation example

### DIFF
--- a/example/animation.rb
+++ b/example/animation.rb
@@ -12,7 +12,7 @@ continue = true
 Signal.trap(:INT) { continue = false }
 
 while continue
-  out.rewind
+  out.string = ""
 
   xs = 0...N
   ys = xs.map {|x| Math.sin(2*Math::PI*(x + shift) / N) }

--- a/example/animation.rb
+++ b/example/animation.rb
@@ -25,11 +25,13 @@ while continue
   $stdout.print "\e[0J"
   $stdout.flush
 
-  n = lines.count
-  $stdout.print "\e[#{n}F"
-  shift = (shift + M) % N
-
   sleep 0.2
+
+  if continue
+    n = lines.count
+    $stdout.print "\e[#{n}F"
+    shift = (shift + M) % N
+  end
 end
 
 $stdout.print "\e[0J"

--- a/example/animation.rb
+++ b/example/animation.rb
@@ -12,7 +12,7 @@ continue = true
 Signal.trap(:INT) { continue = false }
 
 while continue
-  out.string = ""
+  out.truncate(0)
 
   xs = 0...N
   ys = xs.map {|x| Math.sin(2*Math::PI*(x + shift) / N) }

--- a/example/animation.rb
+++ b/example/animation.rb
@@ -22,13 +22,14 @@ while continue
   lines.each do |line|
     $stdout.print "\r#{line}"
   end
+  $stdout.print "\e[0J"
   $stdout.flush
 
-  if continue
-    n = lines.count
-    $stdout.print "\e[#{n}F"
-    shift = (shift + M) % N
-  end
+  n = lines.count
+  $stdout.print "\e[#{n}F"
+  shift = (shift + M) % N
 
   sleep 0.2
 end
+
+$stdout.print "\e[0J"


### PR DESCRIPTION
This pull request fixes the problem of showing "1000" in animation example.

![image](https://user-images.githubusercontent.com/5798442/102077534-d102f280-3e4c-11eb-9430-92aa8206c84e.png)

The plot contains the ANSI escape code.
Even if the length of the string printed on the terminal does not change, the actual length of the string may change.
If the string is too short to overwrite all the characters, you will see "1000" left at the end.