### PR TITLE
Addressing color palette issue in issue #34

### DIFF
--- a/example/issue34.rb
+++ b/example/issue34.rb
@@ -1,0 +1,39 @@
+#!/bin/env ruby
+
+$LOAD_PATH << "#{__dir__}/../lib"
+require "unicode_plot"
+
+#
+# Example of using the 256 color pallette
+#
+
+# dummy plot-line to set canvas
+plt = UnicodePlot.lineplot([0,0],[0,0], title: "256-color", color: 0,
+                           xlim: [0,31], ylim: [0,31],
+                           width: 33, height: 32, canvas: :braille)
+# sweep some colored lines using 256 color palette
+(0..255).each do |colornum|
+  x1 = (colornum / 32).floor * 4
+  x2 = x1 + 3
+  y = colornum % 32
+  UnicodePlot.lineplot!(plt, [x1, x2],[y, y], color: colornum)
+end
+plt.render
+
+#
+# Example of using standard 8-color pallete with line-plots and named colors
+# When lines cross over each other, some 'mixing' effect happens that will
+# blend colors by OR'ing their value.
+#
+# Noting that 16-color cannot be accessed with line-plot, as
+# the ':light_*' colors and ':black' are not accepted.
+
+colorlist = %i[ normal red green yellow blue magenta cyan white ]
+plt = UnicodePlot.lineplot([0,0],[0,0], title: "8-color-mixing", color: 0,
+                           xlim: [0,15], ylim: [0,15],
+                           width: 33, height: 16, canvas: :braille)
+colorlist.each_with_index do |color, y|
+  UnicodePlot.lineplot!(plt, [0, 15],[y*2, y*2], color: color)
+  UnicodePlot.lineplot!(plt, [y*2, y*2],[0, 15],  color: color)
+end
+plt.render

--- a/lib/unicode_plot/braille_canvas.rb
+++ b/lib/unicode_plot/braille_canvas.rb
@@ -46,7 +46,7 @@ module UnicodePlot
       index = index_at(char_x - 1, char_y - 1)
       if index
         @grid[index] = (@grid[index].ord | BRAILLE_SIGNS[char_x_off - 1][char_y_off - 1]).chr(Encoding::UTF_8)
-        @colors[index] |= COLOR_ENCODE[color]
+        @colors[index] |= COLOR_ENCODE.fetch(color, color)
       end
       color
     end

--- a/lib/unicode_plot/lookup_canvas.rb
+++ b/lib/unicode_plot/lookup_canvas.rb
@@ -29,7 +29,7 @@ module UnicodePlot
       index = index_at(char_x - 1, char_y - 1)
       if index
         @grid[index] |= lookup_encode(char_x_off - 1, char_y_off - 1)
-        @colors[index] |= COLOR_ENCODE[color]
+        @colors[index] |= COLOR_ENCODE.fetch(color, color)
       end
     end
 

--- a/lib/unicode_plot/styled_printer.rb
+++ b/lib/unicode_plot/styled_printer.rb
@@ -80,7 +80,7 @@ module UnicodePlot
     end
 
     def print_color(out, color, *args)
-      color = COLOR_DECODE[color]
+      color = COLOR_DECODE.fetch(color, color)
       print_styled(out, *args, color: color)
     end
 


### PR DESCRIPTION
Some support for 256 color mode was allowed in the styled_printer.rb, however it could not be fully accessed.
I have updated the code to allow for a numeric value of a color (0..255) to be used, or a symbol.

Some things that i have found doing this:
- The normal use for coloring is to use a named color (e.g. `color: :blue`).  Definitions for the light colors (e.g. `:light_blue`) and black exist, but are not accessible to plotting.  I am unsure if this is a bug or feature.
- The normal plotting case uses a binary-OR function `|` to OR together the color's number for a given screen element.  This is a nice effect for 8-color mode (e.g. can blend blue and yellow to make green), but this may not give a desired result for 256 color mode (e.g. color 0b11110000 and color 0b00001111 will blend to color 0b11111111)
- support for 24b color is not supported in the existing code or part of this gem.  if this is desired, i would recommend using something like the 'paint' gem, though this will add a dependency.

I believe this will fix issue #34 from @kojix2 , but If there is a desire to support the full range of the basic 16 ANSI color palette or blending is needed for the 256 color palette then we will need to consider more complex methods to handle it.