### PR TITLE
Update Gemfile to use stable version of YARD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@ source "https://rubygems.org/"
 
 gemspec
 
-# Temporary use this for module_function decorator support
-gem "yard", github: "mrkn/yard", branch: "module_function_decorator"
+gem "yard"


### PR DESCRIPTION
Since the `module_function` decorator has been merged into Yard, there is no need to use a fork. 
See https://github.com/lsegal/yard/pull/1365
